### PR TITLE
Use additional_dependencies instead of preinstall

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -3,3 +3,8 @@
     entry: js-beautify
     language: node
     files: \.js$
+    args: []
+
+    # Use additional_dependencies to install the actual node package
+    additional_dependencies: ['js-beautify@1.5.10']
+    minimum_pre_commit_version: 0.7.0

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-    "name": "__dummy_package",
+    "name": "dummy_package",
     "description": "Note: double curly-braces because python .format",
-    "version": "0.0.0",
-    "scripts": {
-        "preinstall": "npm install js-beautify@1.5.10 -g"
-    }
+    "version": "0.0.0"
 }


### PR DESCRIPTION
This pre-commit hook is currently broken.  The `preinstall` fails with the latest pre-commit.  
`additional_dependencies` is the correct way of installing js-beautify
